### PR TITLE
Fixes for newer GROMACS versions

### DIFF
--- a/auto_scripts/gmx_run.py
+++ b/auto_scripts/gmx_run.py
@@ -116,7 +116,7 @@ neu_charge = int(subprocess.check_output(current_p + "/neutralise.sh", shell=Tru
 # Solvate and neutralise
 subprocess.call("%s %s editconf -f filename.gro -o filename_proc.gro -c -d 1.0 -bt cubic"%(gmx_cmd, quiet), shell=True)
 subprocess.call("%s %s solvate -cp filename_proc.gro -cs spc216.gro -o filename_solv.gro -p topol.top"%(gmx_cmd, quiet), shell=True)
-subprocess.call("%s %s grompp -f %s -c filename_solv.gro -p topol.top -o ions.tpr"%(gmx_cmd, quiet, ion_script), shell=True)
+subprocess.call("%s %s grompp -f %s -c filename_solv.gro -p topol.top -o ions.tpr -maxwarn 1"%(gmx_cmd, quiet, ion_script), shell=True)
     
 if neu_charge > 0:
     subprocess.call("echo 'SOL' | %s %s genion -s ions.tpr -o filename_ions.gro -p topol.top -pname NA -nname CL -nn %i"%(gmx_cmd, quiet, neu_charge), shell=True)
@@ -139,7 +139,7 @@ else:
 logger.info("> Minimisation complete. Initialising equilibriation...")
 _ = bs.nvtrun(temp)
 
-subprocess.call("%s %s grompp -f nvt.mdp -c em.gro -p topol.top -o nvt.tpr"%(gmx_cmd, quiet), shell=True)
+subprocess.call("%s %s grompp -f nvt.mdp -c em.gro -r em.gro -p topol.top -o nvt.tpr"%(gmx_cmd, quiet), shell=True)
 
 if n_proc != 1:
     subprocess.call("mpirun -np %i gmx_mpi %s mdrun -ntomp %i %s -s nvt.tpr"%(n_proc, quiet, ntomp, gpu_cmd), shell=True)

--- a/auto_scripts/gmx_run.py
+++ b/auto_scripts/gmx_run.py
@@ -31,7 +31,7 @@ parser.add_argument('-dt', metavar="dumptime", default=2500, required=False, hel
 parser.add_argument('-t', metavar="temp", default=310.15, required=False, help='Temperate of simulation (default 310.15K)')
 parser.add_argument('-p', metavar="press", default=1.0, required=False, help='Pressure of simulation (default 1 bar)')
 parser.add_argument('-s', metavar="skip", default=1, required=False, help='How many frames to skip during parsing (default None)')
-parser.add_argument('-np', metavar="no_proc", default=1, required=False, help="Number of CPUs to run in parallel. If one, runs in serial (Default 1)")
+parser.add_argument('-np', metavar="no_proc", default=1, required=False, help="Number of CPUs to run in parallel. If set to 1 or not specified, use GROMACS default behavior (default is 1)")
 parser.add_argument('-gpu', metavar="gpu", default=-1, required=False, help="GPU ID to map to. 0000 (i.e. first registered one) is the default. But if not specified, then it is assumed you're not using a gpu")
 parser.add_argument('-minim', metavar="min_script", default=current_p + "/minim.mdp", required=False, help="Path to minimisation script, default is the minim script in the auto_scripts folder")
 parser.add_argument('-v', action="store_true", help='Verbose (I want updates!)')

--- a/auto_scripts/jabberdock.py
+++ b/auto_scripts/jabberdock.py
@@ -82,8 +82,8 @@ logger.info("> Beginning gromacs run...")
 recep_name = pdb1.split('.')[0]
 lig_name = pdb2.split('.')[0]
 
-subprocess.call('python %s/gmx_run.py -i %s -ff %s -np %i -gpu %i -ntomp %i'%(current_p, pdb1, ff, n_proc, gpu, ntomp), shell=True)
-subprocess.call('python %s/gmx_run.py -i %s -ff %s -np %i -gpu %i -ntomp %i'%(current_p, pdb2, ff, n_proc, gpu, ntomp), shell=True)
+subprocess.call('python %s/gmx_run.py -i %s -ff %s -gpu %i'%(current_p, pdb1, ff, gpu), shell=True)
+subprocess.call('python %s/gmx_run.py -i %s -ff %s -gpu %i'%(current_p, pdb2, ff, gpu), shell=True)
 
 logger.info("> Converting MD output to STID maps...")
 

--- a/run_jabberdock.sh
+++ b/run_jabberdock.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Starting from minimal Ubuntu 18.4 install :)
+
+# get c compiler
+sudo apt install -y build-essential cmake wget
+
+# get gromacs
+wget -q --show-progress http://ftp.gromacs.org/pub/gromacs/gromacs-2020.2.tar.gz
+tar xzf gromacs-2020.2.tar.gz
+cd gromacs-2020.2/
+mkdir build
+cd build
+cmake .. -DGMX_BUILD_OWN_FFTW=ON -DREGRESSIONTEST_DOWNLOAD=ON >> gromacs-build.log 2>&1
+make -j24 >> gromacs-build.log 2>&1
+sudo make install >> gromacs-build.log 2>&1
+cd ~
+
+# get conda with python 2.7
+wget -q --show-progress https://repo.anaconda.com/miniconda/Miniconda2-py27_4.8.3-Linux-x86_64.sh 
+bash Miniconda2-py27_4.8.3-Linux-x86_64.sh -b -p $HOME/miniconda 
+source $HOME/miniconda/bin/activate
+conda init
+
+# install python packages
+conda install -y numpy scipy cython pandas scikit-learn scikit-image matplotlib mpi4py dill
+conda install -y -c conda-forge vmd
+
+# TODO make environment.yml with these versions
+# numpy-1.16.6
+# scipy-1.2.1
+# cython-0.29.14 
+# pandas-0.22.0
+# scikit-learn-0.20.3
+# scikit-image
+# matplotlib-2.2.3
+# dill-0.3.2
+# mpi4py-3.0.3
+# mpich-3.3.2 
+# vmd-1.9.3
+
+# NOTE fixes in this version of JabberDock are probably needed for gromacs > 5.x
+git clone https://github.com/aizvorski/JabberDock
+
+# NOTE POW_v2 and biobox have to be linked in the home directory, location is hardwired in a few places
+ln -s JabberDock/POW_v2 ~/POW_v2
+ln -s JabberDock/biobox ~/biobox
+
+# NOTE this doesn't install with setuptools, but it does cythonize
+cd JabberDock && python setup.py install && cd ~
+cd biobox && python setup.py install && cd ~
+
+# NOTE the python path needs to be set too; eg import biobox works because home directory is in the python path
+echo 'export PATH=$PATH:/home/ubuntu/JabberDock/auto_scripts' >> ~/.bashrc
+echo 'export PYTHONPATH=/home/ubuntu/JabberDock/:/home/ubuntu/' >> ~/.bashrc
+source ~/.bashrc
+source $HOME/miniconda/bin/activate
+
+mkdir jd_tutorial
+cd jd_tutorial
+cp ~/JabberDock/tutorial/*pdb ./
+
+jabberdock.py -ir 1dfj_0.pdb -il 1dfj_1.pdb -np 12 -ntomp 4


### PR DESCRIPTION
This pull request allows running with newer GROMACS versions (tested 2020.3; probably needed for any version 2018 or newer).

1. During solvation, "gmx grompp -c filename_solv.gro -p topol.top -o ions.tpr" produces an error:

> WARNING 1 [file topol.top, line 17464]:
>   You are using Ewald electrostatics in a system with net charge. This can
>   lead to severe artifacts, such as ions moving into regions with low
>   dielectric, due to the uniform background charge. We suggest to
>   neutralize your system with counter ions, possibly in combination with a
>   physiological salt concentration.
> 
> Fatal error:
> Too many warnings (1).
> If you are sure all warnings are harmless, use the -maxwarn option.

Fix: add -maxwarn 1

2. During equilibration, "gmx grompp -f nvt.mdp -c em.gro -p topol.top -o nvt.tpr" produces another error:

> Fatal error:
> Cannot find position restraint file restraint.gro (option -r).
> From GROMACS-2018, you need to specify the position restraint coordinate files
> explicitly to avoid mistakes, although you can still use the same file as you
> specify for the -c option.

Fix: add  -r em.gro

3. The default GROMACS build does not have a gmx_mpi command - even if MPI is available; instead, gmx with no options seems to pick a reasonable combination of MPI and OpenMP to use all available processors.  Thus, launch gmx_run.py by default without specifying -np or -ntomp options, which calls gmx and allows the default (good) behavior to happen.  However the options if passed work exactly as before.  Tested: full utilization on 48-core machine (AWS c5.12xlarge instance), ~45 minutes to run MD on the tutorial proteins.   See also:  http://www.gromacs.org/Documentation/Acceleration_and_parallelization